### PR TITLE
Fix prompt for multi-byte characters.

### DIFF
--- a/src/text_prompt.rs
+++ b/src/text_prompt.rs
@@ -38,7 +38,7 @@ impl TextRenderStyle {
     pub fn render(&self, state: &TextState) -> String {
         match self {
             Self::Default => state.value().to_string(),
-            Self::Password => "*".repeat(state.value().len()),
+            Self::Password => "*".repeat(state.len()),
             Self::Invisible => String::new(),
         }
     }
@@ -91,7 +91,7 @@ impl<'a> StatefulWidget for TextPrompt<'a> {
         let width = area.width as usize;
         let height = area.height as usize;
         let value = self.render_style.render(state);
-        let value_length = value.len();
+        let value_length = value.chars().count();
 
         let line = Line::from(vec![
             state.status().symbol(),
@@ -100,7 +100,7 @@ impl<'a> StatefulWidget for TextPrompt<'a> {
             " › ".cyan().dim(),
             Span::raw(value),
         ]);
-        let prompt_length = line.width() - value_length;
+        let prompt_length = line.to_string().chars().count() - value_length;
         let lines = wrap(line, width).take(height).collect_vec();
 
         // constrain the position to the area

--- a/src/text_state.rs
+++ b/src/text_state.rs
@@ -90,4 +90,28 @@ impl State for TextState<'_> {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use crate::{State, TextState};
+
+    #[test]
+    fn insert_multibyte_start() {
+        let mut test = TextState::new().with_value("ää");
+        test.move_start();
+        test.push('Ö');
+        assert_eq!(test.value(), "Öää");
+    }
+    #[test]
+    fn insert_multibyte_middle() {
+        let mut test = TextState::new().with_value("ää");
+        test.move_right();
+        test.push('Ö');
+        assert_eq!(test.value(), "äÖä");
+    }
+    #[test]
+    fn insert_multibyte_end() {
+        let mut test = TextState::new().with_value("ää");
+        test.move_end();
+        test.push('Ö');
+        assert_eq!(test.value(), "ääÖ");
+    }
+}


### PR DESCRIPTION
Before this contribution, entering characters that consists of multiple bytes lead to undesired behaviour such as panics.
This results from the position previous position handling inside the prompt.
The String::len() returns the size of the string in bytes. Since a single unicode scalar value may consist of multiple bytes, this is not useful to determine the position inside the prompt. The panic occured in the State::push() method and resulted from the attempt to insert at a byte index that does not represent a character boundary.
See:
https://doc.rust-lang.org/stable/std/primitive.str.html#method.len https://doc.rust-lang.org/stable/std/string/struct.String.html#method.insert

Fixes https://github.com/joshka/tui-prompts/issues/40