### PR TITLE
fix: delete and backspace behavior for multi-byte characters

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -131,16 +131,24 @@ pub trait State {
         if position == self.len() {
             return;
         }
-        self.value_mut().remove(position);
+        *self.value_mut() = chain!(
+            self.value().chars().take(position),
+            self.value().chars().skip(position + 1)
+        )
+        .collect();
     }
 
     fn backspace(&mut self) {
-        let position = self.position().saturating_sub(1);
-        if position == self.len() {
+        let position = self.position();
+        if position == 0 {
             return;
         }
-        *self.position_mut() = position;
-        self.value_mut().remove(position);
+        *self.value_mut() = chain!(
+            self.value().chars().take(position.saturating_sub(1)),
+            self.value().chars().skip(position)
+        )
+        .collect();
+        *self.position_mut() = position.saturating_sub(1);
     }
 
     fn move_right(&mut self) {

--- a/src/text_state.rs
+++ b/src/text_state.rs
@@ -95,23 +95,80 @@ mod tests {
 
     #[test]
     fn insert_multibyte_start() {
-        let mut test = TextState::new().with_value("ää");
+        let mut test = TextState::new().with_value("äë");
         test.move_start();
-        test.push('Ö');
-        assert_eq!(test.value(), "Öää");
+        test.push('Ï');
+        assert_eq!(test.value(), "Ïäë");
+        assert_eq!(test.position(), 1);
     }
     #[test]
     fn insert_multibyte_middle() {
-        let mut test = TextState::new().with_value("ää");
+        let mut test = TextState::new().with_value("äë");
         test.move_right();
-        test.push('Ö');
-        assert_eq!(test.value(), "äÖä");
+        test.push('Ï');
+        assert_eq!(test.value(), "äÏë");
+        assert_eq!(test.position(), 2);
     }
     #[test]
     fn insert_multibyte_end() {
-        let mut test = TextState::new().with_value("ää");
+        let mut test = TextState::new().with_value("äë");
         test.move_end();
-        test.push('Ö');
-        assert_eq!(test.value(), "ääÖ");
+        test.push('Ï');
+        assert_eq!(test.value(), "äëÏ");
+        assert_eq!(test.position(), 3);
+    }
+
+    #[test]
+    fn delete_multibyte_start() {
+        let mut test = TextState::new().with_value("äë");
+        test.move_start();
+        test.delete();
+        assert_eq!(test.value(), "ë");
+        assert_eq!(test.position(), 0);
+    }
+
+    #[test]
+    fn delete_multibyte_middle() {
+        let mut test = TextState::new().with_value("äë");
+        test.move_right();
+        test.delete();
+        assert_eq!(test.value(), "ä");
+        assert_eq!(test.position(), 1);
+    }
+
+    #[test]
+    fn delete_multibyte_end() {
+        let mut test = TextState::new().with_value("äë");
+        test.move_end();
+        test.delete();
+        assert_eq!(test.value(), "äë");
+        assert_eq!(test.position(), 2);
+    }
+
+    #[test]
+    fn backspace_multibyte_start() {
+        let mut test = TextState::new().with_value("äë");
+        test.move_start();
+        test.backspace();
+        assert_eq!(test.value(), "äë");
+        assert_eq!(test.position(), 0);
+    }
+
+    #[test]
+    fn backspace_multibyte_middle() {
+        let mut test = TextState::new().with_value("äë");
+        test.move_right();
+        test.backspace();
+        assert_eq!(test.value(), "ë");
+        assert_eq!(test.position(), 0);
+    }
+
+    #[test]
+    fn backspace_multibyte_end() {
+        let mut test = TextState::new().with_value("äë");
+        test.move_end();
+        test.backspace();
+        assert_eq!(test.value(), "ä");
+        assert_eq!(test.position(), 1);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/joshka/tui-prompts/issues/56
